### PR TITLE
Support for rails 5.1.0

### DIFF
--- a/lib/rocket_pants/railtie.rb
+++ b/lib/rocket_pants/railtie.rb
@@ -39,7 +39,7 @@ module RocketPants
 
     initializer "rocket_pants.setup_caching" do |app|
       if RocketPants.caching_enabled?
-        app.middleware.insert 'Rack::Runtime', RocketPants::CacheMiddleware
+        app.middleware.insert Rack::Runtime, RocketPants::CacheMiddleware
       end
     end
 

--- a/lib/rocket_pants/railtie.rb
+++ b/lib/rocket_pants/railtie.rb
@@ -39,7 +39,7 @@ module RocketPants
 
     initializer "rocket_pants.setup_caching" do |app|
       if RocketPants.caching_enabled?
-        run_time_middleware = if Rails.version.to_i > 4
+        run_time_middleware = if Rails::VERSION::MAJOR >= 5
           Rack::Runtime
         else
           "Rack::Runtime"

--- a/lib/rocket_pants/railtie.rb
+++ b/lib/rocket_pants/railtie.rb
@@ -39,7 +39,12 @@ module RocketPants
 
     initializer "rocket_pants.setup_caching" do |app|
       if RocketPants.caching_enabled?
-        app.middleware.insert Rack::Runtime, RocketPants::CacheMiddleware
+        run_time_middleware = if Rails.version.to_i > 4
+          Rack::Runtime
+        else
+          "Rack::Runtime"
+        end
+        app.middleware.insert run_time_middleware, RocketPants::CacheMiddleware
       end
     end
 


### PR DESCRIPTION
Added support for rails 5.1.0.

[Rails do not support anymore strings or symbols for middleware class names.](https://github.com/rails/rails/issues/25525)