### PR TITLE
Bugsnag v6 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ if (moneta_version = ENV["MONETA_VERSION"])
   gem 'moneta', moneta_version
 end
 
-gem 'rspec', '~>3.3.0'
+gem 'rspec', '~>3.3.2'
 
 if (wp_version = ENV['WILL_PAGINATE_VERSION'])
   gem 'will_paginate', wp_version

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ if (moneta_version = ENV["MONETA_VERSION"])
   gem 'moneta', moneta_version
 end
 
-gem 'rspec'
+gem 'rspec', '~>3.3.2'
 
 if (wp_version = ENV['WILL_PAGINATE_VERSION'])
   gem 'will_paginate', wp_version

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ if (moneta_version = ENV["MONETA_VERSION"])
   gem 'moneta', moneta_version
 end
 
-gem 'rspec', '~>3.3.2'
+gem 'rspec'
 
 if (wp_version = ENV['WILL_PAGINATE_VERSION'])
   gem 'will_paginate', wp_version

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ if (moneta_version = ENV["MONETA_VERSION"])
   gem 'moneta', moneta_version
 end
 
-gem 'rspec', '~>3.3.2'
+gem 'rspec', '~>3.3.0'
 
 if (wp_version = ENV['WILL_PAGINATE_VERSION'])
   gem 'will_paginate', wp_version

--- a/lib/rocket_pants/controller/rescuable.rb
+++ b/lib/rocket_pants/controller/rescuable.rb
@@ -23,7 +23,13 @@ module RocketPants
         end
       },
       :bugsnag => lambda { |controller, exception, request|
-        controller.send(:notify_bugsnag, exception, request: request)
+        if controller.respond_to?(:notify_bugsnag, true)
+          controller.send(:notify_bugsnag, exception, request: request)
+        else
+          # Bugsnag v6 removed #notify_bugsnag controller method
+          # Use #notify directly
+          Bugsnag.notify(exception)
+        end
       }
     }
 

--- a/spec/rocket_pants/controller/error_handling_spec.rb
+++ b/spec/rocket_pants/controller/error_handling_spec.rb
@@ -75,6 +75,9 @@ describe RocketPants::ErrorHandling do
           before :each do
             controller_class.use_named_exception_notifier :bugsnag
             stub.instance_of(controller_class).notify_bugsnag {}
+            Bugsnag = Class.new do	
+              define_singleton_method(:notify) { |exception| }	
+            end
           end
 
           it 'should send notification when it is the named exception notifier' do


### PR DESCRIPTION
Bugsnag v6 removed the private method `notify_bugsnag`. 
This PR will use the public method when the private method is not available.  